### PR TITLE
button/shadows

### DIFF
--- a/src/sass/components/_btn.scss
+++ b/src/sass/components/_btn.scss
@@ -19,6 +19,7 @@
   &:active,
   &:focus {
     background: var(--accent-first-color);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 }
 
@@ -101,6 +102,7 @@
   &:active,
   &:focus {
     background: var(--accent-first-color);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 }
 
@@ -125,6 +127,11 @@
   }
   & .button__arrow--margin {
     margin-left: 11px;
+  }
+  &:hover,
+  &:active,
+  &:focus {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 }
 .button__contacts--white {


### PR DESCRIPTION
добавляет тени при hover  в Моб меню и разделе Сontact и Аbout ( классы button__about и .button__contacts)